### PR TITLE
Build for buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.ocf.berkeley.edu/theocf/debian:stretch
+ARG DIST
+FROM docker.ocf.berkeley.edu/theocf/debian:${DIST}
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 packagePipeline(
-    dists: ['stretch'],
+    dists: ['stretch', 'buster'],
 )
 
 // vim: ft=groovy

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 DECKSCHRUBBER_TAG := v0.6.0
 
-.PHONY: build-image
-build-image:
-	docker build -t deckschrubber-build .
+.PHONY: build_%
+build_%:
+	docker build --build-arg DIST=$* -t deckschrubber-build .
 
 .PHONY: package_%
-package_%: build-image
+package_%: build_%
 	mkdir -p "dist_$*"
 	docker run -e "DECKSCHRUBBER_TAG=${DECKSCHRUBBER_TAG}" \
 		-e "DIST_TAG=$*" \


### PR DESCRIPTION
For testing, I ran `make -j 2 package_stretch package_buster` and it worked (produced both packages)

I changed the `Dockerfile` a bit to be parameterized by distribution (since both have go 1.11 this works fine) and changed the build step in the `Makefile` to be parameterized too.